### PR TITLE
refactor: create mixin to share helper functions across repos

### DIFF
--- a/src/controllers/organization.controller.ts
+++ b/src/controllers/organization.controller.ts
@@ -83,10 +83,12 @@ export class OrganizationController {
 
     // create query to get all orgs and their planters
     if (filter?.where) {
-      filter.where = await this.organizationRepository.applyOrganizationWhereClause(
-        filter.where,
-        organizationId.valueOf(),
-      );
+      filter.where =
+        await this.organizationRepository.applyOrganizationWhereClause(
+          filter.where,
+          organizationId.valueOf(),
+          'orgs',
+        );
     }
 
     const childOrgs = await this.organizationRepository.find(filter);

--- a/src/controllers/planter.controller.ts
+++ b/src/controllers/planter.controller.ts
@@ -54,6 +54,7 @@ export class PlanterController {
       where = await this.planterRepository.applyOrganizationWhereClause(
         whereWithoutOrganizationId,
         organizationId,
+        'planter',
       );
     }
     // console.log('get /planter/count where -->', where);
@@ -85,6 +86,7 @@ export class PlanterController {
       filter.where = await this.planterRepository.applyOrganizationWhereClause(
         whereWithoutOrganizationId,
         organizationId,
+        'planter',
       );
     }
 

--- a/src/controllers/planterOrganization.controller.ts
+++ b/src/controllers/planterOrganization.controller.ts
@@ -140,11 +140,16 @@ export class PlanterOrganizationController {
   ): Promise<PlanterRegistration[]> {
     // console.log('/organization/{organizationId}/planter-registration');
 
-    const sql = `SELECT * FROM planter_registrations
+    const sql = `SELECT *, devices.manufacturer FROM planter_registrations
+        JOIN devices ON devices.android_id=planter_registrations.device_identifier
         LEFT JOIN (
-        SELECT region.name AS country, region.geom FROM region, region_type
-        WHERE region_type.type='country' AND region.type_id=region_type.id
-    ) AS region ON ST_DWithin(region.geom, planter_registrations.geom, 0.01)`;
+          SELECT
+            region.name AS country,
+            region.geom FROM region, region_type
+          WHERE region_type.type='country'
+          AND region.type_id=region_type.id
+        ) AS region
+        ON ST_DWithin(region.geom, planter_registrations.geom, 0.01)`;
 
     const params = {
       filter,

--- a/src/controllers/planterOrganization.controller.ts
+++ b/src/controllers/planterOrganization.controller.ts
@@ -62,9 +62,8 @@ export class PlanterOrganizationController {
       const filterOrgId = organizationId;
 
       if (filterOrgId && filterOrgId !== orgId) {
-        const entityIds = await this.planterRepository.getEntityIdsByOrganizationId(
-          orgId,
-        );
+        const entityIds =
+          await this.planterRepository.getEntityIdsByOrganizationId(orgId);
         orgId = entityIds.includes(filterOrgId) ? filterOrgId : orgId;
       }
 
@@ -72,6 +71,7 @@ export class PlanterOrganizationController {
       where = await this.planterRepository.applyOrganizationWhereClause(
         whereWithoutOrganizationId,
         orgId,
+        'planter',
       );
     }
 
@@ -103,9 +103,8 @@ export class PlanterOrganizationController {
       const filterOrgId = organizationId;
 
       if (filterOrgId && filterOrgId !== orgId) {
-        const entityIds = await this.planterRepository.getEntityIdsByOrganizationId(
-          orgId,
-        );
+        const entityIds =
+          await this.planterRepository.getEntityIdsByOrganizationId(orgId);
         orgId = entityIds.includes(filterOrgId) ? filterOrgId : orgId;
       }
 
@@ -113,6 +112,7 @@ export class PlanterOrganizationController {
       filter.where = await this.planterRepository.applyOrganizationWhereClause(
         whereWithoutOrganizationId,
         orgId,
+        'planter',
       );
     }
 

--- a/src/controllers/trees.controller.ts
+++ b/src/controllers/trees.controller.ts
@@ -57,6 +57,7 @@ export class TreesController {
       where = await this.treesRepository.applyOrganizationWhereClause(
         whereWithoutOrganizationId,
         organizationId,
+        'trees',
       );
     }
 
@@ -90,6 +91,7 @@ export class TreesController {
       filter.where = await this.treesRepository.applyOrganizationWhereClause(
         whereWithoutOrganizationId,
         organizationId,
+        'trees',
       );
     }
 

--- a/src/controllers/treesOrganization.controller.ts
+++ b/src/controllers/treesOrganization.controller.ts
@@ -61,6 +61,7 @@ export class TreesOrganizationController {
       where = await this.treesRepository.applyOrganizationWhereClause(
         whereWithoutOrganizationId,
         orgId,
+        'trees',
       );
     }
 
@@ -100,6 +101,7 @@ export class TreesOrganizationController {
       filter.where = await this.treesRepository.applyOrganizationWhereClause(
         whereWithoutOrganizationId,
         orgId,
+        'trees',
       );
     }
 

--- a/src/js/buildFilterQuery.js
+++ b/src/js/buildFilterQuery.js
@@ -28,6 +28,20 @@ export function buildFilterQuery(selectStmt, params) {
 
         const whereObjClause = connector._buildWhere(modelName, safeWhere);
 
+        //add the modelName to each requested field to avoid ambiguity in more complex queries
+        console.log('whereObjClause.sql -------> ', whereObjClause.sql);
+
+        const tableName =
+          modelName.toLowerCase() === 'planterregistration'
+            ? 'planter_registrations'
+            : modelName.toLowerCase();
+        const newQueryFields = whereObjClause.sql
+          .replace(/"/, `"${tableName}.`)
+          .replace(/AND "/gi, `AND "${tableName}.`)
+          .replace(/"/g, '');
+
+        whereObjClause.sql = newQueryFields;
+
         if (whereObjClause.sql) {
           const hasWhere = /WHERE(?![^(]*\))/i.test(selectStmt);
           query.sql += ` ${hasWhere ? 'AND' : 'WHERE'} ${whereObjClause.sql}`;

--- a/src/mixins/utils.repository-mixin.ts
+++ b/src/mixins/utils.repository-mixin.ts
@@ -1,14 +1,14 @@
 import { MixinTarget } from '@loopback/core';
 import { CrudRepository, Model } from '@loopback/repository';
 import expect from 'expect-runtime';
-import { buildFilterQuery } from '../js/buildFilterQuery';
-import { utils } from '../js/utils';
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export function UtilsRepositoryMixin<
   M extends Model,
   R extends MixinTarget<CrudRepository<M>>,
 >(superClass: R) {
   return class extends superClass {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     [x: string]: any;
     // put the shared code here
     async getEntityIdsByOrganizationId(
@@ -80,13 +80,11 @@ export function UtilsRepositoryMixin<
         const planterIds = await this.getNonOrganizationPlanterIds();
         // if planter repository request
         if (model === 'planter') {
-          return {
-            or: [{ organizationId: null }, { id: { inq: planterIds } }],
-          };
+          return { id: { inq: planterIds } };
         } else {
           // if trees or other repository request
           return {
-            or: [
+            and: [
               { plantingOrganizationId: null },
               { planterId: { inq: planterIds } },
             ],

--- a/src/mixins/utils.repository-mixin.ts
+++ b/src/mixins/utils.repository-mixin.ts
@@ -80,13 +80,6 @@ export function UtilsRepositoryMixin<
         const planterIds = await this.getNonOrganizationPlanterIds();
         // if planter repository request
         if (model === 'planter') {
-          // return {
-          //   and: [
-          //     { organizationId: null },
-          //     { 'planter.id': { inq: planterIds } },
-          //   ],
-          // };
-          // could just do this if we didn't need to use 'planter.id' to avoid errors with adding other filters
           return { id: { inq: planterIds } };
         } else {
           // if trees or other repository request

--- a/src/mixins/utils.repository-mixin.ts
+++ b/src/mixins/utils.repository-mixin.ts
@@ -80,6 +80,13 @@ export function UtilsRepositoryMixin<
         const planterIds = await this.getNonOrganizationPlanterIds();
         // if planter repository request
         if (model === 'planter') {
+          // return {
+          //   and: [
+          //     { organizationId: null },
+          //     { 'planter.id': { inq: planterIds } },
+          //   ],
+          // };
+          // could just do this if we didn't need to use 'planter.id' to avoid errors with adding other filters
           return { id: { inq: planterIds } };
         } else {
           // if trees or other repository request
@@ -102,7 +109,7 @@ export function UtilsRepositoryMixin<
           return {
             or: [
               { organizationId: { inq: entityIds } },
-              { id: { inq: planterIds } },
+              { 'planter.id': { inq: planterIds } },
             ],
           };
         } else {

--- a/src/mixins/utils.repository-mixin.ts
+++ b/src/mixins/utils.repository-mixin.ts
@@ -1,0 +1,122 @@
+import { MixinTarget } from '@loopback/core';
+import { CrudRepository, Model } from '@loopback/repository';
+import expect from 'expect-runtime';
+import { buildFilterQuery } from '../js/buildFilterQuery';
+import { utils } from '../js/utils';
+
+export function UtilsRepositoryMixin<
+  M extends Model,
+  R extends MixinTarget<CrudRepository<M>>,
+>(superClass: R) {
+  return class extends superClass {
+    [x: string]: any;
+    // put the shared code here
+    async getEntityIdsByOrganizationId(
+      organizationId: number,
+    ): Promise<Array<number>> {
+      expect(organizationId).number();
+      expect(this).property('execute').defined();
+      const result = await this.execute(
+        `select * from getEntityRelationshipChildren(${organizationId})`,
+        [],
+      );
+      return result.map((e) => e.entity_id);
+    }
+
+    async applyOrganizationWhereClause(
+      where: Object | undefined,
+      organizationId: number | undefined,
+      model: string,
+    ): Promise<Object | undefined> {
+      if (!where || organizationId === undefined) {
+        return Promise.resolve(where);
+      }
+
+      // if planter or tree repository request
+      if (model === 'trees' || model === 'planter') {
+        const organizationWhereClause = await this.getOrganizationWhereClause(
+          organizationId,
+          model,
+        );
+        return {
+          and: [where, organizationWhereClause],
+        };
+      } else {
+        const entityIds = await this.getEntityIdsByOrganizationId(
+          organizationId,
+        );
+        return {
+          and: [where, { id: { inq: entityIds } }],
+        };
+      }
+    }
+
+    async getPlanterIdsByOrganizationId(
+      organizationId: number,
+    ): Promise<Array<number>> {
+      expect(organizationId).number();
+      const result = await this.execute(
+        `select * from planter where organization_id in (select entity_id from getEntityRelationshipChildren(${organizationId}))`,
+        [],
+      );
+      expect(result).match([{ id: expect.any(Number) }]);
+      return result.map((e) => e.id);
+    }
+
+    async getNonOrganizationPlanterIds(): Promise<Array<number>> {
+      const result = await this.execute(
+        `select * from planter where organization_id isnull`,
+        [],
+      );
+      expect(result).match([{ id: expect.any(Number) }]);
+      return result.map((e) => e.id);
+    }
+
+    async getOrganizationWhereClause(
+      organizationId: number,
+      model: string,
+    ): Promise<Object> {
+      if (organizationId === null) {
+        const planterIds = await this.getNonOrganizationPlanterIds();
+        // if planter repository request
+        if (model === 'planter') {
+          return {
+            or: [{ organizationId: null }, { id: { inq: planterIds } }],
+          };
+        } else {
+          // if trees or other repository request
+          return {
+            or: [
+              { plantingOrganizationId: null },
+              { planterId: { inq: planterIds } },
+            ],
+          };
+        }
+      } else {
+        const planterIds = await this.getPlanterIdsByOrganizationId(
+          organizationId,
+        );
+        const entityIds = await this.getEntityIdsByOrganizationId(
+          organizationId,
+        );
+        // if planter repository request
+        if (model === 'planter') {
+          return {
+            or: [
+              { organizationId: { inq: entityIds } },
+              { id: { inq: planterIds } },
+            ],
+          };
+        } else {
+          // if trees or other repository request
+          return {
+            or: [
+              { plantingOrganizationId: { inq: entityIds } },
+              { planterId: { inq: planterIds } },
+            ],
+          };
+        }
+      }
+    }
+  };
+}

--- a/src/repositories/organization.repository.ts
+++ b/src/repositories/organization.repository.ts
@@ -1,42 +1,22 @@
+import { Constructor, inject } from '@loopback/core';
 import { DefaultCrudRepository } from '@loopback/repository';
-import { Organization, OrganizationRelations } from '../models';
 import { TreetrackerDataSource } from '../datasources';
-import { inject } from '@loopback/core';
-import expect from 'expect-runtime';
+import { UtilsRepositoryMixin } from '../mixins/utils.repository-mixin';
+import { Organization, OrganizationRelations } from '../models';
 
-export class OrganizationRepository extends DefaultCrudRepository<
+export class OrganizationRepository extends UtilsRepositoryMixin<
   Organization,
-  typeof Organization.prototype.id,
-  OrganizationRelations
-> {
+  Constructor<
+    DefaultCrudRepository<
+      Organization,
+      typeof Organization.prototype.id,
+      OrganizationRelations
+    >
+  >
+>(DefaultCrudRepository) {
   constructor(
     @inject('datasources.treetracker') dataSource: TreetrackerDataSource,
   ) {
     super(Organization, dataSource);
-  }
-
-  async getEntityIdsByOrganizationId(
-    organizationId: number,
-  ): Promise<Array<number>> {
-    expect(organizationId).number();
-    expect(this).property('execute').defined();
-    const result = await this.execute(
-      `select * from getEntityRelationshipChildren(${organizationId})`,
-      [],
-    );
-    return result.map((e) => e.entity_id);
-  }
-
-  async applyOrganizationWhereClause(
-    where: Object | undefined,
-    organizationId: number | undefined,
-  ): Promise<Object | undefined> {
-    if (!where || organizationId === undefined) {
-      return Promise.resolve(where);
-    }
-    const entityIds = await this.getEntityIdsByOrganizationId(organizationId);
-    return {
-      and: [where, { id: { inq: entityIds } }],
-    };
   }
 }

--- a/src/repositories/planter.repository.ts
+++ b/src/repositories/planter.repository.ts
@@ -1,3 +1,4 @@
+import { Constructor, inject, Getter } from '@loopback/core';
 import {
   DefaultCrudRepository,
   repository,
@@ -9,17 +10,22 @@ import {
 } from '@loopback/repository';
 import { Planter, PlanterRelations, PlanterRegistration } from '../models';
 import { TreetrackerDataSource } from '../datasources';
-import { inject, Getter } from '@loopback/core';
 import { PlanterRegistrationRepository } from './planterRegistration.repository';
+import { UtilsRepositoryMixin } from '../mixins/utils.repository-mixin';
 import expect from 'expect-runtime';
 import { buildFilterQuery } from '../js/buildFilterQuery';
 import { utils } from '../js/utils';
 
-export class PlanterRepository extends DefaultCrudRepository<
+export class PlanterRepository extends UtilsRepositoryMixin<
   Planter,
-  typeof Planter.prototype.id,
-  PlanterRelations
-> {
+  Constructor<
+    DefaultCrudRepository<
+      Planter,
+      typeof Planter.prototype.id,
+      PlanterRelations
+    >
+  >
+>(DefaultCrudRepository) {
   public readonly planterRegs: HasManyRepositoryFactory<
     PlanterRegistration,
     typeof Planter.prototype.id
@@ -40,75 +46,6 @@ export class PlanterRepository extends DefaultCrudRepository<
     );
   }
 
-  async getEntityIdsByOrganizationId(
-    organizationId: number,
-  ): Promise<Array<number>> {
-    expect(organizationId).number();
-    expect(this).property('execute').defined();
-    const result = await this.execute(
-      `select * from getEntityRelationshipChildren(${organizationId})`,
-      [],
-    );
-    return result.map((e) => e.entity_id);
-  }
-
-  async getPlanterIdsByOrganizationId(
-    organizationId: number,
-  ): Promise<Array<number>> {
-    expect(organizationId).number();
-    const result = await this.execute(
-      `select * from planter where organization_id in (select entity_id from getEntityRelationshipChildren(${organizationId}))`,
-      [],
-    );
-    expect(result).match([{ id: expect.any(Number) }]);
-    return result.map((e) => e.id);
-  }
-
-  async getNonOrganizationPlanterIds(): Promise<Array<number>> {
-    const result = await this.execute(
-      `select * from planter where organization_id isnull`,
-      [],
-    );
-    expect(result).match([{ id: expect.any(Number) }]);
-    return result.map((e) => e.id);
-  }
-
-  async getOrganizationWhereClause(organizationId: number): Promise<Object> {
-    if (organizationId === null) {
-      const planterIds = await this.getNonOrganizationPlanterIds();
-      return {
-        and: [{ organizationId: null }, { 'planter.id': { inq: planterIds } }],
-      };
-    } else {
-      const planterIds = await this.getPlanterIdsByOrganizationId(
-        organizationId,
-      );
-      const entityIds = await this.getEntityIdsByOrganizationId(organizationId);
-
-      return {
-        or: [
-          { organizationId: { inq: entityIds } },
-          { 'planter.id': { inq: planterIds } },
-        ],
-      };
-    }
-  }
-
-  async applyOrganizationWhereClause(
-    where: Object | undefined,
-    organizationId: number | undefined,
-  ): Promise<Object | undefined> {
-    if (!where || organizationId === undefined) {
-      return Promise.resolve(where);
-    }
-    const organizationWhereClause = await this.getOrganizationWhereClause(
-      organizationId,
-    );
-    return {
-      and: [where, organizationWhereClause],
-    };
-  }
-
   getPlanterRegistrationJoinClause(deviceIdentifier: string): string {
     if (deviceIdentifier === null) {
       return `LEFT JOIN planter_registrations
@@ -120,7 +57,8 @@ export class PlanterRepository extends DefaultCrudRepository<
       WHERE (planter_registrations.device_identifier='${deviceIdentifier}')`;
   }
 
-  // loopback .find() wasn't applying the org filters
+  // default .find() wasn't applying the org filters
+
   async findWithOrg(
     filter?: Filter<Planter>,
     deviceIdentifier?: string,
@@ -194,7 +132,6 @@ export class PlanterRepository extends DefaultCrudRepository<
 
       return <Promise<Count>>await this.execute(query.sql, query.params).then(
         (res) => {
-          // responds with count value as a string
           return (res && res[0]) || { count: 0 };
         },
       );

--- a/src/repositories/planter.repository.ts
+++ b/src/repositories/planter.repository.ts
@@ -12,7 +12,7 @@ import { Planter, PlanterRelations, PlanterRegistration } from '../models';
 import { TreetrackerDataSource } from '../datasources';
 import { PlanterRegistrationRepository } from './planterRegistration.repository';
 import { UtilsRepositoryMixin } from '../mixins/utils.repository-mixin';
-import expect from 'expect-runtime';
+// import expect from 'expect-runtime';
 import { buildFilterQuery } from '../js/buildFilterQuery';
 import { utils } from '../js/utils';
 
@@ -70,9 +70,14 @@ export class PlanterRepository extends UtilsRepositoryMixin<
 
     try {
       if (this.dataSource.connector) {
-        const columnNames = this.dataSource.connector
-          .buildColumnNames('Planter', filter)
-          .replace('"id"', 'planter.id as "id"');
+        // const columnNames = this.dataSource.connector
+        //   .buildColumnNames('Planter', filter)
+        //   .replace('"id"', 'planter.id as "id"')
+        //   .replace('"first_name"', 'planter.first_name as "first_name"')
+        //   .replace('"last_name"', 'planter.last_name as "last_name"')
+        //   .replace('"email"', 'planter.email as "email"')
+        //   .replace('"organization"', 'planter.organization as "organization"')
+        //   .replace('"phone"', 'planter.phone as "phone"');
 
         let selectStmt;
         if (deviceIdentifier) {
@@ -80,7 +85,7 @@ export class PlanterRepository extends UtilsRepositoryMixin<
             deviceIdentifier,
           )}`;
         } else {
-          selectStmt = `SELECT ${columnNames} FROM planter`;
+          selectStmt = `SELECT planter.* FROM planter`;
         }
 
         const params = {
@@ -90,7 +95,6 @@ export class PlanterRepository extends UtilsRepositoryMixin<
         };
 
         const query = buildFilterQuery(selectStmt, params);
-        // console.log('query ---------', query);
 
         const result = await this.execute(query.sql, query.params, options);
         return <Planter[]>result.map((planter) => utils.convertCamel(planter));

--- a/src/repositories/planter.repository.ts
+++ b/src/repositories/planter.repository.ts
@@ -12,7 +12,6 @@ import { Planter, PlanterRelations, PlanterRegistration } from '../models';
 import { TreetrackerDataSource } from '../datasources';
 import { PlanterRegistrationRepository } from './planterRegistration.repository';
 import { UtilsRepositoryMixin } from '../mixins/utils.repository-mixin';
-// import expect from 'expect-runtime';
 import { buildFilterQuery } from '../js/buildFilterQuery';
 import { utils } from '../js/utils';
 
@@ -70,15 +69,6 @@ export class PlanterRepository extends UtilsRepositoryMixin<
 
     try {
       if (this.dataSource.connector) {
-        // const columnNames = this.dataSource.connector
-        //   .buildColumnNames('Planter', filter)
-        //   .replace('"id"', 'planter.id as "id"')
-        //   .replace('"first_name"', 'planter.first_name as "first_name"')
-        //   .replace('"last_name"', 'planter.last_name as "last_name"')
-        //   .replace('"email"', 'planter.email as "email"')
-        //   .replace('"organization"', 'planter.organization as "organization"')
-        //   .replace('"phone"', 'planter.phone as "phone"');
-
         let selectStmt;
         if (deviceIdentifier) {
           selectStmt = `SELECT planter.* FROM planter ${this.getPlanterRegistrationJoinClause(


### PR DESCRIPTION
## Description
Organization of helper functions to reduce duplication across repositories

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines


**What kind of change does this PR introduce?** 
 - [x] Enhancement


## Issue

**What is the current behavior?**

There are duplicate functions to help build queries for filtering by organization information in the Trees, Planter, and Organization repositories


**What is the new behavior?**

Can now use a mixin with a repository to import the helper functions from utils.repository-mixin.ts

Steps taken:
 - [x]  Created utils.repository-mixin.ts to house helper functions to integrate organization info into filter queries for use by repositories
 - [x]  Moved helper functions from Trees, Planter, & Organization repositories to utils.repository-mixin.ts to reduce duplication
 - [x]  added parameters to handle the Trees and Planters query builds differently based on different table names for the organization and id fields
 - [x]  update the controllers to pass the necessary information for building the queries
 - [x]  fix the query for when the organization has a value of null, represented as "Not Set" in the UI dropdown



## Breaking change
**Does this PR introduce a breaking change?** 
 - [x] No