### PR TITLE
feat: add show_in_map field

### DIFF
--- a/src/models/planter.model.ts
+++ b/src/models/planter.model.ts
@@ -194,6 +194,18 @@ export class Planter extends Entity {
   })
   imageRotation?: Number;
 
+  @property({
+    type: Boolean,
+    required: true,
+    default: false,
+    postgresql: {
+      columnName: 'show_in_map',
+      dataType: 'boolean',
+      nullable: 'NO',
+    },
+  })
+  show_in_map: boolean;
+
   @hasMany(() => PlanterRegistration, { keyTo: 'planterId' })
   planterRegs: PlanterRegistration[];
 


### PR DESCRIPTION
## Description
This addresses the issue https://github.com/Greenstand/treetracker-admin-client/issues/1038 by adding the field in the column. 

This is the BE change to add the field for the show_in_map field. The migration run through npm did not work on my end anymore so I ran this SQL query manually. 

```
ALTER TABLE public.planter
ADD COLUMN show_in_map BOOLEAN DEFAULT false NOT NULL
```
## Discussion 1

Should we create a script that sets the existing records to `show_in_map=True`. This is because if we just deploy this change, all the growers will be hidden so there should be some Backward Compat handling. 

1. For all existing planters, we make them show in map still
2. For all new planters that will be created after deployment, they will default to show in map = false

## Discussion 2

I have a few thoughts I want to share here. I mainly followed the requirement in the issue but I'm wondering if we want to be updating the API calls in the Map Web  FE Client to add a filter? Or should we be adding this at the auth level?

I haven't fully checked the feasibility or how I will do it yet but I was thinking something like: 
1. `show_in_map` field can be renamed as something like `status: str enum` or `is_valid: boolean`. This way the field is more "generic" and there's more flexibility in how it can be used in the case that requirements get updated
4. By default we do return the data from the API if `is_valid != true` or `status != 'valid'`. We will base it off of user role/permissions rather than search params or filters. If the sensitivity of this requirement increases, there is more security in the BE. 