### PR TITLE
feat: Deploy keycloak branch to K8s dev env

### DIFF
--- a/.github/workflows/treetracker-admin-api-keycloak-build-deploy.yml
+++ b/.github/workflows/treetracker-admin-api-keycloak-build-deploy.yml
@@ -1,0 +1,93 @@
+name: Keycloak Admin API CI/CD Pipeline
+
+on:
+  push:
+    branches:
+      - keycloak
+  pull_request:
+    branches:
+      - keycloak
+
+env:
+  project-directory: ./
+
+jobs:
+  test:
+    name: Test API Project
+    runs-on: ubuntu-latest
+    if: |
+      !contains(github.event.head_commit.message, 'skip-ci')
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js 16.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: '16.x'
+      - name: npm clean install
+        run: npm ci
+        working-directory: ${{ env.project-directory }}
+      - name: run ESLint
+        run: npm run lint
+        working-directory: ${{ env.project-directory }}
+      - name: build api project
+        run: npm run build
+        working-directory: ${{ env.project-directory }}
+      - name: run api tests
+        run: npm run test:ci
+        working-directory: ${{ env.project-directory }}
+
+  release:
+    name: Build and Deploy Keycloak
+    needs: test
+    runs-on: ubuntu-latest
+    if: |
+      !contains(github.event.head_commit.message, 'skip-ci') &&
+      github.event_name == 'push' &&
+      github.repository == 'Greenstand/treetracker-admin-api'
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: keycloak
+
+      - name: Set short SHA
+        id: sha
+        run: echo "short=$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_OUTPUT
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        id: docker_build_release
+        uses: docker/build-push-action@v2
+        with:
+          context: ./
+          file: ./Dockerfile
+          push: true
+          tags: greenstand/treetracker-admin-api:keycloak-${{ steps.sha.outputs.short }}
+
+      - name: Install kustomize
+        run: curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash
+
+      - name: Update kustomize image tag
+        run: (cd deployment/overlays/keycloak-development && ../../../kustomize edit set image greenstand/treetracker-admin-api:keycloak-${{ steps.sha.outputs.short }} )
+
+      - name: Commit kustomization file with new image tag
+        if: |
+          !startsWith(github.event.head_commit.message, 'chore')
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git commit -am "chore: bump keycloak docker image tag keycloak-${{ steps.sha.outputs.short }} [skip ci]"
+
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: keycloak

--- a/.github/workflows/treetracker-admin-api-keycloak-build-deploy.yml
+++ b/.github/workflows/treetracker-admin-api-keycloak-build-deploy.yml
@@ -19,10 +19,10 @@ jobs:
       !contains(github.event.head_commit.message, 'skip-ci')
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js 16.x
-        uses: actions/setup-node@v1
+      - name: Use Node.js 20.x
+        uses: actions/setup-node@v3
         with:
-          node-version: '16.x'
+          node-version: '20.x'
       - name: npm clean install
         run: npm ci
         working-directory: ${{ env.project-directory }}

--- a/deployment/argocd-apps/README.md
+++ b/deployment/argocd-apps/README.md
@@ -1,0 +1,71 @@
+# ArgoCD Application Setup for Keycloak
+
+## Overview
+
+This document explains how to set up an ArgoCD Application that automates Keycloak deployments for the TreeTracker Admin API. Once configured, ArgoCD continuously manages the deployment without requiring manual intervention.
+
+## What This Does
+
+The ArgoCD Application defined in this directory:
+
+- **Monitors:** the `keycloak` branch in your repository
+- **Source Path:** `deployment/overlays/keycloak-development/`
+- **Build Process:** ArgoCD runs Kustomize internally to build the deployment manifests
+- **Target Namespace:** `admin-api`
+
+## Setup Frequency
+
+**This is a one-time setup.** Run the following command once to create the ArgoCD Application:
+
+```bash
+kubectl apply -f deployment/argocd-apps/treetracker-admin-api-keycloak-app.yaml
+```
+
+After this initial setup, ArgoCD automatically:
+
+- Detects changes every 3 minutes
+- Rebuilds manifests using Kustomize
+- Applies updates to your cluster
+
+**No recurring manual steps are required.**
+
+## Automated Deployment Flow
+
+Once the application is created, deployments happen automatically:
+
+Developer pushes code
+↓
+CI builds Docker image
+↓
+CI updates kustomization.yaml
+↓
+ArgoCD detects change (every 3 minutes)
+↓
+ArgoCD runs: kustomize build + kubectl apply
+↓
+✅ Deployed!
+
+
+## Verification
+
+Use these commands to verify the application and deployment status:
+
+```bash
+# Check ArgoCD application status
+kubectl get application treetracker-admin-api-keycloak-app -n argocd
+
+# Check Keycloak deployment
+kubectl get deployment keycloak-treetracker-admin-api -n admin-api
+
+# Check Keycloak pods
+kubectl get pods -n admin-api | grep keycloak
+```
+
+## Files in This Directory
+
+- `treetracker-admin-api-keycloak-app.yaml` — ArgoCD Application definition
+- `README.md` — This documentation
+
+---
+
+Once set up, ArgoCD handles all Keycloak deployments automatically.

--- a/deployment/argocd-apps/treetracker-admin-api-keycloak-app.yaml
+++ b/deployment/argocd-apps/treetracker-admin-api-keycloak-app.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: treetracker-admin-api-keycloak-app
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/Greenstand/treetracker-admin-api
+    targetRevision: keycloak
+    path: deployment/overlays/keycloak-development
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: admin-api
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/deployment/overlays/keycloak-development/keycloak-client-sealed-secret.yaml
+++ b/deployment/overlays/keycloak-development/keycloak-client-sealed-secret.yaml
@@ -1,0 +1,14 @@
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  creationTimestamp: null
+  name: keycloak-client-secret
+  namespace: admin-api
+spec:
+  encryptedData:
+    client-secret: AgAqlxjAPMN6sI1XqmPmFghji2QiA3IjXvmwvdsOO4tDe1tQJTbWkqYNFoQdSuzRGZkrPHBsbERAMH7nDIXH/Aq5+vX9gEqEgGv/AzBSnqg7TGcoG+BN30M+u+u5TE9R3Oi5fa5TGzPCQdpm9Oba/MUoiipy1wTqnPB7Y0RnWdN+ukTn6tu0pHfpCvibYIoskQ5hF4J+1l396isbeTxBjTk2vxC6KRk/MiwqHZ/neK5Xzf3emkrwnsgGrF8og+lj4Wiv+rqWNhKWXN72e7J7mNdC5hTtB+t9+eyOEpI8Q0pJU4s41NnSAkq9mUxOYPaPTAqOmvCcwR9ce+7EOoyD5bz9ZLiar22s3eoBQsOU6jtwW1Z/jPC2ypSy1cLXb/KJkb44xDWC22IpBKhiUejWCgvl3K+PwExUYcPziCAQ/FoKzL0BrikSui9ySiR6VpUVM2/FFylJR9gYF7qtzVFO+17EGrzAMsrR27yItVCggrG5PRAXCjbKj70gUsPMWLpqs6mWXkJqjqrmaPfK7iX/iUxfC4OApTVZmMf9t3GalXY9J1GzGgbG/Eo/Mh41EhylT8giy0KHld/SQyG28xA8yghqRU+pmSwI+M50U3kpy9U82OfWuw1N7Uo2oUMdpWBijot5dr85nXv2wYNNMsfneeGJnzVNasY4FdfGttDgf3+bV/6RQDlSTv8OiGkTIcdwX547ykye/Vh8kmZAZcn3/Mr5sjS9L8LrzKz2WlFSh0uobw==
+  template:
+    metadata:
+      creationTimestamp: null
+      name: keycloak-client-secret
+      namespace: admin-api

--- a/deployment/overlays/keycloak-development/kustomization.yaml
+++ b/deployment/overlays/keycloak-development/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- treetracker-admin-api-deployment.yaml
+- treetracker-admin-api-service.yaml
+- treetracker-admin-api-mapping.yaml
+
+images:
+- name: greenstand/treetracker-admin-api
+  newName: greenstand/treetracker-admin-api
+  newTag: keycloak-2.26.3

--- a/deployment/overlays/keycloak-development/kustomization.yaml
+++ b/deployment/overlays/keycloak-development/kustomization.yaml
@@ -2,11 +2,12 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- treetracker-admin-api-deployment.yaml
-- treetracker-admin-api-service.yaml
-- treetracker-admin-api-mapping.yaml
+  - treetracker-admin-api-deployment.yaml
+  - treetracker-admin-api-service.yaml
+  - treetracker-admin-api-mapping.yaml
+  - keycloak-client-sealed-secret.yaml
 
 images:
-- name: greenstand/treetracker-admin-api
-  newName: greenstand/treetracker-admin-api
-  newTag: keycloak-2.26.3
+  - name: greenstand/treetracker-admin-api
+    newName: greenstand/treetracker-admin-api
+    newTag: keycloak-2.26.3

--- a/deployment/overlays/keycloak-development/treetracker-admin-api-deployment.yaml
+++ b/deployment/overlays/keycloak-development/treetracker-admin-api-deployment.yaml
@@ -47,3 +47,18 @@ spec:
                   key: messageQueue
             - name: ENABLE_VERIFY_PUBLISHING
               value: 'true'
+            - name: KEYCLOAK_URL
+              value: 'https://dev-k8s.treetracker.org/keycloak'
+            - name: KEYCLOAK_REALM
+              value: 'treetracker'
+            - name: KEYCLOAK_CLIENT_ID
+              value: 'treetracker-admin-client-be'
+            - name: KEYCLOAK_ADMIN_ID
+              value: 'treetracker-admin-client-be'
+            - name: KEYCLOAK_CLIENT_EXPECTED_CLIENT_ID
+              value: 'treetracker-admin-client-fe'
+            - name: KEYCLOAK_ADMIN_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: keycloak-client-secret
+                  key: client-secret

--- a/deployment/overlays/keycloak-development/treetracker-admin-api-deployment.yaml
+++ b/deployment/overlays/keycloak-development/treetracker-admin-api-deployment.yaml
@@ -1,0 +1,49 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: keycloak-treetracker-admin-api
+  namespace: admin-api
+  labels:
+    app: keycloak-treetracker-admin-api
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: keycloak-treetracker-admin-api
+  template:
+    metadata:
+      labels:
+        app: keycloak-treetracker-admin-api
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: doks.digitalocean.com/node-pool
+                    operator: In
+                    values:
+                      - microservices-node-pool
+      containers:
+        - name: treetracker-admin-api
+          image: greenstand/treetracker-admin-api
+          ports:
+            - containerPort: 80
+          env:
+            - name: JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: treetracker-api-jwt
+                  key: jwt
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: database-connection
+                  key: db
+            - name: RABBIT_MQ_URL
+              valueFrom:
+                secretKeyRef:
+                  name: treetracker-rabbitmq-connection
+                  key: messageQueue
+            - name: ENABLE_VERIFY_PUBLISHING
+              value: 'true'

--- a/deployment/overlays/keycloak-development/treetracker-admin-api-mapping.yaml
+++ b/deployment/overlays/keycloak-development/treetracker-admin-api-mapping.yaml
@@ -1,0 +1,16 @@
+apiVersion: getambassador.io/v2
+kind: Mapping
+metadata:
+  name: keycloak-treetracker-admin-api
+  namespace: admin-api
+spec:
+  prefix: /api/keycloak-admin/
+  service: keycloak-treetracker-admin-api
+  rewrite: /
+  timeout_ms: 0
+  cors:
+    origins: '*'
+    methods: GET, POST, PATCH, PUT, OPTIONS, DELETE
+    headers:
+      - Content-Type
+      - Authorization

--- a/deployment/overlays/keycloak-development/treetracker-admin-api-service.yaml
+++ b/deployment/overlays/keycloak-development/treetracker-admin-api-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: keycloak-treetracker-admin-api
+  namespace: admin-api
+spec:
+  selector:
+    app: keycloak-treetracker-admin-api
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: 3000


### PR DESCRIPTION
feat: deploy keycloak branch to dedicated k8s dev environment

Add complete deployment to enable keycloak API version to run alongside existing dev API in the same Kubernetes cluster.

### CI/CD Pipeline
- .github/workflows/treetracker-admin-api-keycloak-build-deploy.yml
  - Triggers on keycloak branch pushes
  - Runs tests, lints, and builds
  - Builds Docker image tagged with git short SHA (keycloak-<sha7>)
  - Auto-updates kustomization.yaml with new image tag
  - Commits and pushes changes to trigger ArgoCD sync

### ArgoCD Application
- deployment/argocd-apps/treetracker-admin-api-keycloak-app.yaml
  - Monitors keycloak branch for changes
  - Applies manifests from deployment/overlays/keycloak-development/
  - Automated sync with prune and self-heal enabled
  - One-time setup: kubectl apply -f deployment/argocd-apps/treetracker-admin-api-keycloak-app.yaml

- deployment/argocd-apps/README.md
  - Setup and verification instructions
  - Explains automated deployment flow

### Kubernetes Deployment Overlay
- deployment/overlays/keycloak-development/kustomization.yaml
  - Standalone resources (no base dependencies)
  - Image tag management via kustomize

- deployment/overlays/keycloak-development/treetracker-admin-api-deployment.yaml
  - Isolated deployment: keycloak-treetracker-admin-api
  - Unique labels/selectors preventing collision with existing dev deployment
  - Reuses existing dev secrets (database, JWT, RabbitMQ)
  - ENABLE_VERIFY_PUBLISHING: true for dev testing

- deployment/overlays/keycloak-development/treetracker-admin-api-service.yaml
  - Service targeting keycloak deployment
  - Port 80 -> 3000 (internal app port)

- deployment/overlays/keycloak-development/treetracker-admin-api-mapping.yaml
  - Ambassador mapping for API routing
  - Endpoint: /api/keycloak-admin/
  - CORS enabled for frontend connectivity

## Key Design Decisions

### Secret Sharing (no duplication)
Keycloak API uses the same dev environment secrets as existing deployment:
- database-connection (PostgreSQL)
- treetracker-api-jwt (JWT signing)
- treetracker-rabbitmq-connection (RabbitMQ)
This avoids secret duplication and complexity since both use the same dev database.

### SHA-Based Versioning
Docker images tagged with git short SHA (keycloak-a3f8b21) instead of static
version numbers. Ensures each push produces a unique tag that kustomize detects,
triggering automatic ArgoCD sync. No need for semantic-release on a feature branch.

### The CI failed 
on npm ci because of a peer dependency conflict: @loopback/rest-explorer@^5.0.3 requires @loopback/core@^4.0.3, but the project uses @loopback/core@^2.17.0. This was a pre-existing issue on the keycloak branch, not introduced by my changes.
So, I downgraded @loopback/rest-explorer from ^5.0.3 to ^3.3.4 in package.json. Version 3.3.4 is the latest release compatible with @loopback/core@^2.x, which matches the rest of the project's LoopBack stack. Then I regenerated package-lock.json with npm install.

## Endpoint & Access

Frontend connects to: https://dev-k8s.treetracker.org/api/keycloak-admin/
Uses same dev database, RabbitMQ, and JWT secrets as existing dev API
Namespace: admin-api
Isolated pod labels prevent conflicts with existing API deployment